### PR TITLE
Remove Documentation Targets

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -10,5 +10,3 @@ version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets:
-      - SpeziOpenAI


### PR DESCRIPTION
# Remove Documentation Targets

## :recycle: Current situation & Problem
- Address an issue that the documentation is not build using the Swift Package index: https://swiftpackageindex.com/builds/3A8A8343-72D6-4820-A17F-893413E90252

## :bulb: Proposed solution
- Removes the custom documentation targets


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
