### PR TITLE
Updates for Standard changes in Spezi 0.7.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -375,6 +375,9 @@ deployment_target: # Availability checks or attributes shouldn’t be using olde
   iOSApplicationExtension_deployment_target: 16.0
   iOS_deployment_target: 16.0
 
+attributes:
+  attributes_with_arguments_always_on_line_above: false
+
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - .build
   - .swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/MacPaw/OpenAI", .upToNextMinor(from: "0.2.2")),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.5.1")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.3.1")),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", .upToNextMinor(from: "0.4.0")),
         .package(url: "https://github.com/StanfordSpezi/SpeziOnboarding", .upToNextMinor(from: "0.3.0"))
     ],
     targets: [

--- a/Sources/SpeziOpenAI/OpenAIAPIKeyOnboardingStep.swift
+++ b/Sources/SpeziOpenAI/OpenAIAPIKeyOnboardingStep.swift
@@ -13,8 +13,8 @@ import SwiftUI
 
 
 /// View to display an onboarding step for the user to enter an OpenAI API Key.
-public struct OpenAIAPIKeyOnboardingStep<ComponentStandard: Standard>: View {
-    @EnvironmentObject private var openAI: OpenAIComponent<ComponentStandard>
+public struct OpenAIAPIKeyOnboardingStep: View {
+    @EnvironmentObject private var openAI: OpenAIComponent
     private let actionText: String
     private let action: () -> Void
     

--- a/Sources/SpeziOpenAI/OpenAIComponent.swift
+++ b/Sources/SpeziOpenAI/OpenAIComponent.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 
 /// `OpenAIComponent` is a module responsible for to coordinate the interactions with the OpenAI GPT API.
-public class OpenAIComponent<ComponentStandard: Standard>: Component, ObservableObject, ObservableObjectProvider {
+public class OpenAIComponent: Component, ObservableObject, ObservableObjectProvider {
     @Dependency private var localStorage: LocalStorage
     @Dependency private var secureStorage: SecureStorage
     

--- a/Sources/SpeziOpenAI/OpenAIModelSelectionOnboardingStep.swift
+++ b/Sources/SpeziOpenAI/OpenAIModelSelectionOnboardingStep.swift
@@ -13,8 +13,8 @@ import SwiftUI
 
 
 /// View to display an onboarding step for the user to enter change the OpenAI model.
-public struct OpenAIModelSelectionOnboardingStep<ComponentStandard: Standard>: View {
-    @EnvironmentObject private var openAI: OpenAIComponent<ComponentStandard>
+public struct OpenAIModelSelectionOnboardingStep: View {
+    @EnvironmentObject private var openAI: OpenAIComponent
     private let actionText: String
     private let action: () -> Void
     

--- a/Sources/SpeziOpenAI/SpeziOpenAI.docc/SpeziOpenAI.md
+++ b/Sources/SpeziOpenAI/SpeziOpenAI.docc/SpeziOpenAI.md
@@ -17,7 +17,7 @@ Module to interact with the OpenAI API to interact with GPT-based large language
 ```
 class ExampleDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
-        Configuration(standard: /* ... */) {
+        Configuration {
             OpenAIComponent()
             // ...
         }

--- a/Tests/UITests/TestApp/OnboardingView.swift
+++ b/Tests/UITests/TestApp/OnboardingView.swift
@@ -22,13 +22,13 @@ struct OnboardingView: View {
     
     var body: some View {
         NavigationStack(path: $steps) {
-            OpenAIAPIKeyOnboardingStep<TestAppStandard> {
+            OpenAIAPIKeyOnboardingStep {
                 steps.append(.modelSelection)
             }
                 .navigationDestination(for: Step.self) { step in
                     switch step {
                     case .modelSelection:
-                        OpenAIModelSelectionOnboardingStep<TestAppStandard> {
+                        OpenAIModelSelectionOnboardingStep {
                             steps.removeLast()
                         }
                     }

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -13,7 +13,7 @@ import XCTSpezi
 
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
-        Configuration(standard: TestAppStandard()) {
+        Configuration {
             OpenAIComponent()
         }
     }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.5.1;
+				minimumVersion = 0.7.0;
 			};
 		};
 		2FD590502A19E9F000153BE4 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Updates for Standard changes in Spezi 0.7.0

## :recycle: Current situation & Problem
Spezi 0.7.0 changes how `Standard`s are defined. Standards are no longer required for all components.

## :bulb: Proposed solution
This PR migrates to Spezi 0.7.0 and removes the requirement to define a `Standard` when using components in the package that do not use the `Standard`.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
