### PR TITLE
Make OpenAI Model Public in the OpenAI Module

### DIFF
--- a/Sources/SpeziOpenAI/OpenAIModule.swift
+++ b/Sources/SpeziOpenAI/OpenAIModule.swift
@@ -14,7 +14,8 @@ import SpeziSecureStorage
 
 /// `OpenAIModule` is a module responsible for to coordinate the interactions with the OpenAI GPT API.
 public class OpenAIModule: Module, DefaultInitializable {
-    @Module.Model private var model: OpenAIModel
+    /// Model accessible to modules using the ``OpenAIModule`` as a dependency and injected in the SwiftUI environment.
+    @Module.Model public var model: OpenAIModel
     @Dependency private var secureStorage: SecureStorage
     
     


### PR DESCRIPTION
# Make OpenAI Model Public in the OpenAI Module


## :gear: Release Notes 
- Makes the `OpenAIModel` public in the OpenAI module to make it accessible for modules using it as a dependency.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
